### PR TITLE
Feature/eval1 date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "marvel-app",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "marvel-app",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "d3": "^7.9.0",
+        "date-fns": "^4.1.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.26.2",
@@ -4827,6 +4828,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marvel-app",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "d3": "^7.9.0",
+    "date-fns": "^4.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.2",

--- a/src/components/CharacterDetail.jsx
+++ b/src/components/CharacterDetail.jsx
@@ -1,4 +1,5 @@
-
+import React from 'react';
+import FormattedDate from './FormattedDate';
 
 const CharacterDetail = ({character = {}}) => {
     return (
@@ -9,7 +10,9 @@ const CharacterDetail = ({character = {}}) => {
 
             {character.thumbnail && <img src={`${character.thumbnail.path}/standard_large.${character.thumbnail.extension}`} alt={character.name} />}
             <p>{character.description}</p>
-            <p>Date de modification : {character.modified}</p>
+            {/* <p>Date de modification : {character.modified}</p> */}
+            <p><FormattedDate date={character.modified} /></p>
+
         </div>
 
 

--- a/src/components/CharacterDetail.test.jsx
+++ b/src/components/CharacterDetail.test.jsx
@@ -3,6 +3,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import CharacterDetail from './CharacterDetail';
+import { format } from 'date-fns';
 
 const character = {
     name: "Thor",
@@ -34,7 +35,8 @@ describe('CharacterDetail component', () => {
 
     test('renders character modified date', () => {
         render(<CharacterDetail character={character} />);
-        expect(screen.getByText(`Date de modification : ${character.modified}`)).toBeInTheDocument();
+        const formattedDate = format(new Date(character.modified), 'MMM dd, yyyy');
+        expect(screen.getByText(`${formattedDate}`)).toBeInTheDocument();
     });
 
     test('renders correctly with empty character object', () => {

--- a/src/components/CharactersList.jsx
+++ b/src/components/CharactersList.jsx
@@ -19,7 +19,7 @@ export function CharactersList({characters= []}) {
           {characters.map((character) => (
             <li key={character.id}>
               <Link to={`/characters/${character.id}`} style={{ textDecoration: 'none', color: '#333' }}>
-                    <strong>{character.name}</strong> - <FormattedDate date={character.modified} />
+                    <strong>{character.name}</strong> - <small><FormattedDate date={character.modified} /></small>
               </Link>
             </li>
           ))}

--- a/src/components/CharactersList.jsx
+++ b/src/components/CharactersList.jsx
@@ -1,4 +1,6 @@
 import { Link } from "react-router-dom";
+import React from 'react';
+import FormattedDate from './FormattedDate';
 
 export function CharactersList({characters= []}) {
 
@@ -16,8 +18,8 @@ export function CharactersList({characters= []}) {
         <ul id="characters">
           {characters.map((character) => (
             <li key={character.id}>
-              <Link to={`/characters/${character.id}`}>
-              {character.name}
+              <Link to={`/characters/${character.id}`} style={{ textDecoration: 'none', color: '#333' }}>
+                    <strong>{character.name}</strong> - <FormattedDate date={character.modified} />
               </Link>
             </li>
           ))}

--- a/src/components/CharactersList.test.jsx
+++ b/src/components/CharactersList.test.jsx
@@ -4,15 +4,19 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import { CharactersList } from './CharactersList';
 import { BrowserRouter } from 'react-router-dom';
+import { format } from 'date-fns';
 
 const characters = [
     {
         id: "1",
-        name: "Thor"
+        name: "Thor",
+        modified: "2023-01-01"
+
     },
     {
         id: "2",
-        name: "Captain America"
+        name: "Captain America",
+        modified: "2023-02-01"
     }
 ];
 
@@ -27,18 +31,11 @@ describe('CharactersList component', () => {
         expect(characterItems).toHaveLength(characters.length);
     });
 
-    test('renders the correct character names', () => {
+    test('renders the correct formatted dates for each character', () => {
         render(<CharactersList characters={characters} />, { wrapper: BrowserRouter });
-        characters.forEach(character => {
-            expect(screen.getByText(character.name)).toBeInTheDocument();
-        });
-    });
-
-    test('renders the correct links for each character', () => {
-        render(<CharactersList characters={characters} />, { wrapper: BrowserRouter });
-        characters.forEach(character => {
-            const linkElement = screen.getByText(character.name).closest('a');
-            expect(linkElement).toHaveAttribute('href', `/characters/${character.id}`);
-        });
+        const formattedDate1 = format(new Date(characters[0].modified), 'MMM dd, yyyy');
+        const formattedDate2 = format(new Date(characters[1].modified), 'MMM dd, yyyy');
+        expect(screen.getByText(formattedDate1)).toBeInTheDocument();
+        expect(screen.getByText(formattedDate2)).toBeInTheDocument();
     });
 });

--- a/src/components/FormattedDate.jsx
+++ b/src/components/FormattedDate.jsx
@@ -4,7 +4,7 @@ import { fr } from 'date-fns/locale';
 
 
 const FormattedDate = ({ date }) => {
-    const formattedDate = date ? format(new Date(date), 'dd MMMM yyyy') : 'Date non disponible';
+    const formattedDate = date ? format(new Date(date), 'MMM dd, yyyy') : 'Date non disponible';
     return <span>{formattedDate}</span>;
 };
 

--- a/src/components/FormattedDate.jsx
+++ b/src/components/FormattedDate.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { format } from 'date-fns';
+import { fr } from 'date-fns/locale';
+
+
+const FormattedDate = ({ date }) => {
+    const formattedDate = date ? format(new Date(date), 'dd MMMM yyyy') : 'Date non disponible';
+    return <span>{formattedDate}</span>;
+};
+
+export default FormattedDate;

--- a/src/components/FormattedDate.test.jsx
+++ b/src/components/FormattedDate.test.jsx
@@ -1,0 +1,15 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import FormattedDate from './FormattedDate';
+
+describe('FormattedDate component', () => {
+    test('renders without crashing', () => {
+        render(<FormattedDate date="2023-10-10" />);
+    });
+
+    test('displays "Date non disponible" when no date is provided', () => {
+        render(<FormattedDate date={null} />);
+        expect(screen.getByText('Date non disponible')).toBeInTheDocument();
+    });
+});
+


### PR DESCRIPTION
- Afficher la date de modification du personnage (donnée modified d'un personnage) dans un format lisible par un humain
- la date de modification est au format ISO 8601 et ne doit pas être modifiée dans le fichier JSON (sauf éventuellement sur un personnage pour tester le cas d'une date non conforme)
- Ajouter l'affichage de cette date dans la liste des personnages et dans le détail d'un personnage
- Appliquer la bonne pratique permettant d'avoir le même comportement sur les deux pages (composant dédié)